### PR TITLE
Support PHP 8.1

### DIFF
--- a/src/ComposerLockParser/Package.php
+++ b/src/ComposerLockParser/Package.php
@@ -222,7 +222,10 @@ class Package {
             $namespace = $this->autoload['psr-4'];
         }
 
-        return trim(key($namespace), '\\');
+        if (!$namespace = key($namespace)) {
+          return '';
+        }
+        return trim($namespace, '\\');
     }
 
     /**

--- a/src/ComposerLockParser/PackagesCollection.php
+++ b/src/ComposerLockParser/PackagesCollection.php
@@ -59,14 +59,14 @@ class PackagesCollection extends ArrayObject
         return array_key_exists($namespace, $this->getIndexedByNamespace());
     }
 
-    public function offsetSet($index, $package)
+    public function offsetSet($index, $package): void
     {
         if ($package instanceof Package) {
             $this->indexedBy['name'][$package->getName()] = $package;
             $this->indexedBy['namespace'][$package->getNamespace()] = $package;
         }
 
-        return parent::offsetSet($index, $package);
+        parent::offsetSet($index, $package);
     }
 
     /**


### PR DESCRIPTION
Fixed deprecation errors on PHP 8.1. 

Not sure if `#[\ReturnTypeWillChange]` should be used instead of a return type to keep compatbility with < php 7.4.